### PR TITLE
Added an option in config.json that stops the bot from resetting its skin combo when a new player joins.

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,5 +11,6 @@
     "status": "Created by xMistt, enjoy!\nSupport server: https://discord.gg/fnpy",
     "platform": "WIN",
     "debug": false,
-    "friendaccept": true
+    "friendaccept": true,
+    "resetonjoin": true
 }

--- a/fortnite.py
+++ b/fortnite.py
@@ -154,7 +154,7 @@ async def event_device_auth_generate(details: dict, email: str) -> None:
 @client.event
 async def event_ready() -> None:
     print(crayons.green(f'[PartyBot] [{time()}] Client ready as {client.user.display_name}.'))
-
+    await BenBotAsync.set_default_loadout(client, data, fortnitepy.PartyMember)
     for pending in list(client.pending_friends.values()):
         if pending.direction == 'INBOUND':
             friend = await pending.accept() if data["friendaccept"] else await pending.decline()

--- a/fortnite.py
+++ b/fortnite.py
@@ -168,6 +168,7 @@ async def event_ready() -> None:
 async def event_party_invite(invite: fortnitepy.PartyInvitation) -> None:
     await invite.accept()
     print(f'[PartyBot] [{time()}] Accepted party invite from {invite.sender.display_name}.')
+    await BenBotAsync.set_default_loadout(client, data, fortnitepy.PartyMember)
 
 
 @client.event
@@ -184,7 +185,8 @@ async def event_friend_request(request: fortnitepy.PendingFriend) -> None:
 
 @client.event
 async def event_party_member_join(member: fortnitepy.PartyMember) -> None:
-    await BenBotAsync.set_default_loadout(client, data, member)
+    if data['resetonjoin']:
+        await BenBotAsync.set_default_loadout(client, data, member)
 
 
 @client.event


### PR DESCRIPTION
A lot of people have been requesting this so I made it so you can choose to make the bot not reset each time a new player joins, but it will still reset when it is invited to a new party.